### PR TITLE
Add support for RHEL 8 and enable management of "cli" package

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ This module manage Docker.
 This module has been tested to work on the following systems.
 
 * EL 7
+* EL 8
 
 ====
 
@@ -19,20 +20,28 @@ This module has been tested to work on the following systems.
 rpm_url
 -------
 
-- *Default*: 'USE_DEFAULTS'
+- *Default*: 'https://download.docker.com/linux/centos/(7 or 8)/x86_64/stable'
 
 repo_key
 --------
 
-- *Default*: 'USE_DEFAULTS'
+- *Default*: 'https://download.docker.com/linux/centos/gpg'
 
 package_name
 ------------
+Name of the docker server package.  Since version 18.09, docker daemon comes in its own package and command line interface package comes separate (see below).
 
-- *Default*: 'USE_DEFAULTS'
+- *Default*: 'docker-ce'
+
+package_cli_name
+----------------
+Name of the docker client package.  Since version 18.09, docker daemon comes in its own package and command line interface package comes separate (see above).
+
+- *Default*: 'docker-ce-cli'
 
 package_ensure
 --------------
+Leave at default value to get latest available version.  You can specify a specific version also.
 
 - *Default*: 'present'
 
@@ -45,6 +54,12 @@ manage_group_users
 ------------------
 
 - *Default*: 'undef'
+
+manage_cli_package
+------------------
+Set this to 'true' if you are installing a version higher than 18.09 and you want the docker-ce-cli version to be the same as the docker-ce version.
+
+- *Default*: false
 
 manage_containerd
 -----------------

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -3,29 +3,32 @@
 # Manage Docker
 #
 class docker (
-  $repo_ensure        = 'present',
-  $repo_enabled       = 1,
-  $repo_url           = 'USE_DEFAULTS',
-  $repo_key           = 'USE_DEFAULTS',
-  $repo_gpgcheck      = 1,
-  $package_name       = 'USE_DEFAULTS',
-  $package_ensure     = 'present',
-  $socket_group       = 'docker',
-  $manage_containerd  = false,
-  $manage_group_users = undef,
-  $images             = undef,
+  $repo_ensure            = 'present',
+  $repo_enabled           = 1,
+  $repo_url               = 'USE_DEFAULTS',
+  $repo_key               = 'USE_DEFAULTS',
+  $repo_gpgcheck          = 1,
+  $package_name           = 'USE_DEFAULTS',
+  $package_cli_name       = 'USE_DEFAULTS',
+  $package_ensure         = 'present',
+  $socket_group           = 'docker',
+  $manage_cli_package     = false,
+  $manage_containerd      = false,
+  $manage_group_users     = undef,
+  $images                 = undef,
 ) {
 
   case $::osfamily {
     'RedHat': {
       case $::operatingsystemmajrelease {
-        '7': {
-          $default_repo_url     = 'https://download.docker.com/linux/centos/7/x86_64/stable'
-          $default_repo_key     = 'https://download.docker.com/linux/centos/gpg'
-          $default_package_name = 'docker-ce'
+        '7', '8': {
+          $default_repo_url         = 'https://download.docker.com/linux/centos/$::operatingsystemmajrelease/x86_64/stable'
+          $default_repo_key         = 'https://download.docker.com/linux/centos/gpg'
+          $default_package_name     = 'docker-ce'
+          $default_cli_package_name = 'docker-ce-cli'
         }
         default: {
-          fail("Docker supports RedHat like systems with major release of 7 and you have <${::operatingsystemmajrelease}>.")
+          fail("Docker supports RedHat like systems with major release of 7 or 8 and you have <${::operatingsystemmajrelease}>.")
         }
       }
     }
@@ -62,11 +65,14 @@ class docker (
   validate_integer($repo_gpgcheck)
 
   if $package_name == 'USE_DEFAULTS' {
-    $package_name_real = $default_package_name
+    $package_name_real     = $default_package_name
+    $package_cli_name_real = $default_cli_package_name
   } else {
-    $package_name_real = $package_name
+    $package_name_real     = $package_name
+    $package_cli_name_real = $package_cli_name
   }
   validate_string($package_name_real)
+  validate_string($package_cli_name_real)
 
   validate_string($package_ensure)
 
@@ -78,6 +84,12 @@ class docker (
     $manage_containerd_real = $manage_containerd
   }
   validate_bool($manage_containerd_real)
+
+ if is_string($manage_cli_package) {
+    $manage_cli_package_real = str2bool($manage_cli_package)
+  } else {
+    $manage_cli_package_real = $manage_cli_package
+  }
 
   yumrepo { 'docker_yum_repo':
     ensure   => $repo_ensure,
@@ -93,6 +105,14 @@ class docker (
     ensure  => $package_ensure,
     name    => $package_name_real,
     require => Yumrepo['docker_yum_repo'],
+  }
+
+  if $manage_cli_package_real {
+    package { 'docker_cli_package':
+      ensure  => $package_ensure,
+      name    => $package_cli_name_real,
+      require => Yumrepo['docker_yum_repo'],
+    }
   }
 
   file { 'etc_docker_service_d_dir':


### PR DESCRIPTION
Docker version 18.09+ comes in 2 separate packages.  This version
of the module enables management of both packages.